### PR TITLE
Fixing up the manage binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,9 @@ Make sure your credentials are located in `~/.aws/credentials` and you have set 
     $ pip install git+https://github.com/Doerge/Zappa
     $ pip install git+https://github.com/Miserlou/flask-zappa.git@basic_example
     $ curl https://gist.githubusercontent.com/Doerge/0714d7dbd1c4fdf1484c/raw/0ebaa6ba57c240393ff11abfb1703eeabd522c1b/test_app.py > test_app.py
-    $ curl https://raw.githubusercontent.com/Miserlou/flask-zappa/basic_example/manage.py -o venv/lib/python2.7/site-packages/manage.py
     $ curl https://gist.githubusercontent.com/Doerge/3f65ffd74a7b17b49bed/raw/5193db75775bbe1a3523aa655c03dde037b7c6a6/production_settings.py -o production_settings.py
     $ curl https://gist.githubusercontent.com/Doerge/194a01e61194d8021caa/raw/b7b2b9624de3eb4c5167b519cdfc3c57c42ad83a/test_settings.json -o test_settings.json
-    $ python venv/lib/python2.7/site-packages/manage.py deploy production test_settings.json
+    $ flask-zappa deploy production test_settings.json
 
 #### A Note About Databases
 
@@ -98,7 +97,7 @@ Requirements:
 
 To deploy the code to AWS Lambda, and  AWS API-gateway issue:
 
-    python manage.py deploy <environment> zappa_settings.json
+    flask-zappa deploy <environment> zappa_settings.json
 
 where _<environment>_ is an entry (e.g. _production_) in your settings file as described above.
 
@@ -106,7 +105,7 @@ where _<environment>_ is an entry (e.g. _production_) in your settings file as d
 
 After the initial deployment, the code can be updated with:
 
-    python manage.py update <environment> zappa_settings.json
+    flask-zappa update <environment> zappa_settings.json
 
 ## Advanced Usage
 

--- a/bin/flask-zappa
+++ b/bin/flask-zappa
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import json
 import importlib
@@ -8,59 +9,76 @@ import requests
 import click
 
 from zappa.zappa import Zappa
+import flask_zappa
 
 
-def _package(environment, zappa_settings):
-    # Loading settings from json
-    settings = json.load(zappa_settings)
-
-    project_name = settings[environment]['project_name']
-
-    # Make your Zappa object
-    zappa = Zappa()
-
-    # Load environment-specific settings
-    s3_bucket_name = settings[environment]['s3_bucket']
-    vpc_config = settings[environment].get('vpc_config', {})
-    settings_file = settings[environment]['settings_file']
-    if '~' in settings_file:
-        settings_file = settings_file.replace('~', os.path.expanduser('~'))
-    if not os.path.isfile(settings_file):
-        print("Please make sure your settings_file is properly defined.")
-        return
-
-    custom_settings = [
+CUSTOM_SETTINGS = [
         'http_methods',
         'parameter_depth',
         'integration_response_codes',
         'method_response_codes',
         'role_name',
         'aws_region'
-    ]
-    for setting in custom_settings:
-        if setting in settings[environment]:
-            setattr(zappa, setting, settings[environment][setting])
+]
 
-    # Load your AWS credentials from ~/.aws/credentials
-    zappa.load_credentials()
+DEFAULT_SETTINGS = {
+        'vpc_config': {},
+        'delete_zip': True,
+        'touch': True,
+        'memory_size': 256
+}
 
-    # Make sure the necessary IAM execution roles are available
-    zappa.create_iam_roles()
+
+class SettingsError(Exception): pass
+
+
+def apply_zappa_settings(zappa_obj, zappa_settings, environment):
+    '''Load zappa settings, set defaults if needed, and apply to the Zappa object'''
+
+    settings_all = json.load(zappa_settings)
+    settings = settings_all[environment]
+
+    # load defaults for missing options
+    for key,value in DEFAULT_SETTINGS.items():
+        settings[key] = settings.get(key, value)
+
+    if '~' in settings['settings_file']:
+        settings['settings_file'] = settings['settings_file'].replace('~', os.path.expanduser('~'))
+    if not os.path.isfile(settings['settings_file']):
+        raise SettingsError("Please make sure your settings_file "
+                            "is properly defined in {0}.".format(zappa_settings))
+
+    for setting in CUSTOM_SETTINGS:
+        if setting in settings:
+            setattr(zappa, setting, settings[setting])
+
+    return settings
+
+
+def _package(environment, zappa_settings):
+    # Make your Zappa object
+    zappa = Zappa()
+
+    # Load settings and apply them to the Zappa object
+    settings = apply_zappa_settings(zappa, zappa_settings, environment)
 
     # Create the Lambda zip package (includes project and virtualenvironment)
     # Also define the path the handler file so it can be copied to the zip root
     # for Lambda.
-    current_file = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+    module_dir = os.path.dirname(os.path.abspath(flask_zappa.__file__))
+    handler_file = os.path.join(module_dir, 'handler.py')
+    lambda_name = settings['project_name'] + '-' + environment
 
-    handler_file = current_file + os.sep + 'flask_zappa' + os.sep + 'handler.py'
-    lambda_name = project_name + '-' + environment
+    # assume zappa_settings is at the project root
+    #os.chdir(os.path.dirname(zappa_settings))
+
     zip_path = zappa.create_lambda_zip(lambda_name, handler_file=handler_file)
 
-    # Add this environment's Django settings to that zipfile
-    with open(settings_file, 'r') as f:
+    # Add this environment's settings to that zipfile
+    with open(settings['settings_file'], 'r') as f:
         contents = f.read()
         all_contents = contents
-        if 'domain' not in settings[environment]:
+        if 'domain' not in settings:
             script_name = environment
         else:
             script_name = ''
@@ -79,7 +97,7 @@ def _package(environment, zappa_settings):
 
     os.unlink('zappa_settings.py')
 
-    return zappa, settings, s3_bucket_name, lambda_name, zip_path
+    return zappa, settings, lambda_name, zip_path
 
 
 @click.group()
@@ -95,20 +113,29 @@ def deploy(environment, zappa_settings):
     """ Package, create and deploy to Lambda."""
     print(("Deploying " + environment))
 
-    zip_path = None
+    zappa, settings, lambda_name, zip_path = \
+        _package(environment, zappa_settings)
+
+    s3_bucket_name = settings['s3_bucket']
 
     try:
-        zappa, settings, s3_bucket_name, lambda_name, zip_path = \
-            _package(environment, zappa_settings)
+        # Load your AWS credentials from ~/.aws/credentials
+        zappa.load_credentials()
+
+        # Make sure the necessary IAM execution roles are available
+        zappa.create_iam_roles()
 
         # Upload it to S3
         zip_arn = zappa.upload_to_s3(zip_path, s3_bucket_name)
 
         # Register the Lambda function with that zip as the source
         # You'll also need to define the path to your lambda_handler code.
-        lambda_arn = zappa.create_lambda_function(s3_bucket_name, zip_path,
-                                                  lambda_name,
-                                                  'handler.lambda_handler')
+        lambda_arn = zappa.create_lambda_function(bucket=s3_bucket_name,
+                                                  s3_key=zip_path,
+                                                  function_name=lambda_name,
+                                                  handler='handler.lambda_handler',
+                                                  vpc_config=settings['vpc_config'],
+                                                  memory_size=settings['memory_size'])
 
         # Create and configure the API Gateway
         api_id = zappa.create_api_gateway_routes(lambda_arn, lambda_name)
@@ -119,12 +146,12 @@ def deploy(environment, zappa_settings):
         # Remove the uploaded zip from S3, because it is now registered..
         zappa.remove_from_s3(zip_path, s3_bucket_name)
 
-        if settings[environment].get('touch', True):
+        if settings['touch']:
             requests.get(endpoint_url)
     finally:
         try:
             # Finally, delete the local copy our zip package
-            if settings[environment].get('delete_zip', True):
+            if settings['delete_zip']:
                 os.remove(zip_path)
         except:
             print("WARNING: Manual cleanup of the zip might be needed.")
@@ -139,12 +166,20 @@ def update(environment, zappa_settings):
     """ Update an existing deployment."""
     print(("Updating " + environment))
 
-    zip_path = None
+    # Package dependencies, and the source code into a zip
+    zappa, settings, lambda_name, zip_path = \
+        _package(environment, zappa_settings)
+
+    s3_bucket_name = settings['s3_bucket']
 
     try:
-        # Package dependencies, and the source code into a zip
-        zappa, settings, s3_bucket_name, lambda_name, zip_path = \
-            _package(environment, zappa_settings)
+
+        # Load your AWS credentials from ~/.aws/credentials
+        zappa.load_credentials()
+
+        # Update IAM roles if needed
+        zappa.create_iam_roles()
+
 
         # Upload it to S3
         zip_arn = zappa.upload_to_s3(zip_path, s3_bucket_name)
@@ -159,7 +194,7 @@ def update(environment, zappa_settings):
     finally:
         try:
             # Finally, delete the local copy our zip package
-            if settings[environment].get('delete_zip', True):
+            if settings['delete_zip']:
                 os.remove(zip_path)
         except:
             print("WARNING: Manual cleanup of the zip might be needed.")

--- a/flask_zappa/handler.py
+++ b/flask_zappa/handler.py
@@ -14,7 +14,7 @@ from zappa.middleware import ZappaWSGIMiddleware
 
 def lambda_handler(event, context, settings_name="zappa_settings"):
     """ An AWS Lambda function which parses specific API Gateway input into a
-    WSGI request, feeds it to Django, procceses the Django response, and returns
+    WSGI request, feeds it to Flask, procceses the Flask response, and returns
     that back to the API Gateway.
     """
     # Loading settings from a python module
@@ -94,7 +94,10 @@ def lambda_handler(event, context, settings_name="zappa_settings"):
             # absolute on Werkzeug. We can set autocorrect_location_header on
             # the response to False, but it doesn't work. We have to manually
             # remove the host part.
-            location = response.location.split(environ['HTTP_HOST'])[1]
+            location = response.location
+            hostname = 'https://' + environ['HTTP_HOST']
+            if location.startswith(hostname):
+                location = location[len(hostname):]
             raise Exception(location)
         else:
             return zappa_returndict

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ click==6.2
 Flask>=0.10.1
 requests==2.9.1
 Werkzeug==0.11.4
-zappa==0.10.4
+zappa==0.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ click==6.2
 Flask>=0.10.1
 requests==2.9.1
 Werkzeug==0.11.4
-zappa==0.11.3
+zappa==0.11.2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     name='flask-zappa',
     version='0.0.1',
     packages=['flask_zappa'],
+    scripts=['bin/flask-zappa'],
     install_requires=required,  
     include_package_data=True,
     license='MIT License',


### PR DESCRIPTION
I'm renaming it to `flask-zappa` and putting it in the path so you can just run it wherever.

Also:
- refactoring some things to make it a little simpler - we might look at moving some of the config stuff into Zappa itself
- brought in vpc_support from the newer Zappa version
- fix external redirects
